### PR TITLE
feat(hello): add hello module with greeting function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 build/
 .venv/
 .pytest_cache/
+specs/

--- a/specs/add-hello-module/implementation-summary.md
+++ b/specs/add-hello-module/implementation-summary.md
@@ -1,0 +1,32 @@
+## implementation-summary.md
+
+### Overview
+Added a `hello` module to the `testbed` Python package at `src/testbed/hello.py`. The module exports a single function `hello(name: str) -> str` that returns a formatted greeting string. Comprehensive pytest tests verify importability, basic usage, and edge cases.
+
+### Steps Completed
+
+| Step | Title | Status | Commit |
+|------|-------|--------|--------|
+| 1 | Implement the feature | ✅ Done | `9de6f39` |
+| 2 | E2E test | ✅ No-op | N/A |
+
+### Test Summary
+- 3 new tests added in `tests/test_hello.py`
+- Full suite: 14 tests, all passing
+- No coverage regressions
+
+### Files Created/Modified
+
+| File | Description |
+|------|-------------|
+| `src/testbed/hello.py` | New module with `hello(name: str) -> str` function |
+| `tests/test_hello.py` | Pytest tests: importability, basic greeting, empty string |
+
+### How to Run
+```bash
+uv run pytest tests/test_hello.py  # run hello module tests only
+uv run pytest tests/                # run full test suite
+```
+
+### Remaining Work
+- None — implementation is complete and all tests pass

--- a/specs/add-hello-module/plan.md
+++ b/specs/add-hello-module/plan.md
@@ -1,0 +1,29 @@
+# Implementation Plan: Add hello module
+
+## Checklist
+- [x] Step 1: Implement the feature
+- [ ] Step 2: E2E test
+
+---
+
+## Step 1: Implement the feature
+
+**Depends on**: none
+
+**Objective**: Implement all components described in design.md.
+
+**Sub-items**:
+- Create `src/testbed/hello.py` with `hello(name: str) -> str` function returning `f"Hello, {name}!"`
+- Create `tests/test_hello.py` with pytest tests: basic greeting, empty string input, importability
+
+**Related Files**: `src/testbed/hello.py`, `tests/test_hello.py`
+
+**Test Requirements**: Run `pytest tests/test_hello.py` — all integration test cases from design.md section 3 must pass.
+
+---
+
+## Step 2: E2E test
+
+**Depends on**: Step 1
+
+**Objective**: Not applicable — e2e tests were excluded in requirements. This step is a no-op.

--- a/specs/add-hello-module/plan.md
+++ b/specs/add-hello-module/plan.md
@@ -2,7 +2,7 @@
 
 ## Checklist
 - [x] Step 1: Implement the feature
-- [ ] Step 2: E2E test
+- [x] Step 2: E2E test
 
 ---
 

--- a/specs/add-hello-module/progress.md
+++ b/specs/add-hello-module/progress.md
@@ -1,0 +1,5 @@
+## Step 1: Implement the feature
+- **Files changed**: `src/testbed/hello.py`, `tests/test_hello.py`
+- **What was built**: Added hello module with `hello(name: str) -> str` function and 3 pytest tests
+- **Tests**: 3 tests added (importability, basic greeting, empty string), all passing. Full suite: 14 passed
+- **Notes**: None — straightforward implementation matching design spec exactly

--- a/specs/add-hello-module/progress.md
+++ b/specs/add-hello-module/progress.md
@@ -3,3 +3,9 @@
 - **What was built**: Added hello module with `hello(name: str) -> str` function and 3 pytest tests
 - **Tests**: 3 tests added (importability, basic greeting, empty string), all passing. Full suite: 14 passed
 - **Notes**: None — straightforward implementation matching design spec exactly
+
+## Step 2: E2E test
+- **Files changed**: none
+- **What was built**: No-op — e2e tests were excluded in requirements
+- **Tests**: N/A
+- **Notes**: Skipped per requirements decision

--- a/specs/add-hello-module/review-round-1.md
+++ b/specs/add-hello-module/review-round-1.md
@@ -1,0 +1,24 @@
+# Review Round 1
+
+## Verdict: PASS
+
+### Spec Compliance
+- Implementation matches design.md exactly
+- `hello(name: str) -> str` returns `f"Hello, {name}!"` as specified
+- Tests cover all 3 integration test cases from design
+- No modifications to existing files
+
+### Code Quality
+- Clean, minimal implementation — no duplication, no YAGNI violations
+- Idiomatic Python with type annotations
+- Test class structure matches existing test_snake.py conventions
+
+### Correctness & Security
+- No edge case issues (simple string formatting as specified)
+- No security concerns
+- Full test suite passes (14/14)
+
+### Issue Summary
+- 🔴 Major: 0
+- 🟠 Medium: 0
+- 🟡 Minor: 0

--- a/specs/add-hello-module/source-issue
+++ b/specs/add-hello-module/source-issue
@@ -1,0 +1,1 @@
+freematters/testbed#18

--- a/src/testbed/hello.py
+++ b/src/testbed/hello.py
@@ -1,0 +1,5 @@
+"""Hello greeting module."""
+
+
+def hello(name: str) -> str:
+    return f"Hello, {name}!"

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -1,0 +1,15 @@
+"""Unit tests for hello module."""
+
+from testbed.hello import hello
+
+
+class TestHello:
+    def test_importable(self) -> None:
+        """hello function is importable from testbed.hello."""
+        assert callable(hello)
+
+    def test_basic_greeting(self) -> None:
+        assert hello("World") == "Hello, World!"
+
+    def test_empty_string(self) -> None:
+        assert hello("") == "Hello, !"


### PR DESCRIPTION
## Summary

- Add `src/testbed/hello.py` with `hello(name: str) -> str` function returning formatted greeting
- Add `tests/test_hello.py` with pytest tests for importability, basic greeting, and empty string edge case
- All 14 tests pass (3 new + 11 existing)

Closes #18

## Test Plan

- [x] `uv run pytest tests/test_hello.py` — 3 tests pass
- [x] `uv run pytest tests/` — full suite 14 tests pass
- [x] No regressions in existing tests